### PR TITLE
Exposing ServerHandler and setup errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "jsonrpc-http-server"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "hyper 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ fn main() {
     let io = IoHandler::new();
     io.add_method("say_hello", SayHello);
     let server = Server::new(Arc::new(io));
-    server.start("127.0.0.1:3030".to_string(), AccessControlAllowOrigin::Null, 1);
+    server.start("127.0.0.1:3030".to_string(), AccessControlAllowOrigin::Null, 1).unwrap();
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl Server {
 
 	pub fn start(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) -> ServerResult {
 		try!(hyper::Server::http(addr))
-      .handle_threads(ServerHandler::new(self.jsonrpc_handler.clone(), cors_domain), threads)
+			.handle_threads(ServerHandler::new(self.jsonrpc_handler.clone(), cors_domain), threads)
 	}
 
 	pub fn start_async(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) -> thread::JoinHandle<ServerResult> {
@@ -142,7 +142,7 @@ impl Server {
 		let handler = self.jsonrpc_handler.clone();
 		thread::Builder::new().name("jsonrpc_http".to_string()).spawn(move || {
 			try!(hyper::Server::http(address.as_ref() as &str))
-        .handle_threads(ServerHandler::new(handler, cors_domain), threads)
+				.handle_threads(ServerHandler::new(handler, cors_domain), threads)
 		}).expect("RPC thread spawned")
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use self::jsonrpc::{IoHandler};
 pub use hyper::header::AccessControlAllowOrigin;
 
 /// jsonrpc http request handler.
-struct ServerHandler {
+pub struct ServerHandler {
 	jsonrpc_handler: Arc<IoHandler>,
 	cors_domain: AccessControlAllowOrigin,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub struct ServerHandler {
 
 impl ServerHandler {
 	/// Create new request handler.
-	fn new(jsonrpc_handler: Arc<IoHandler>, cors_domain: AccessControlAllowOrigin) -> Self {
+	pub fn new(jsonrpc_handler: Arc<IoHandler>, cors_domain: AccessControlAllowOrigin) -> Self {
 		ServerHandler {
 			jsonrpc_handler: jsonrpc_handler,
 			cors_domain: cors_domain

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ use self::jsonrpc::{IoHandler};
 
 pub use hyper::header::AccessControlAllowOrigin;
 
+pub type ServerResult = Result<hyper::server::Listening, hyper::error::Error>;
+
 /// jsonrpc http request handler.
 pub struct ServerHandler {
 	jsonrpc_handler: Arc<IoHandler>,
@@ -116,7 +118,7 @@ impl hyper::server::Handler for ServerHandler {
 /// 	let io = IoHandler::new();
 /// 	io.add_method("say_hello", SayHello);
 /// 	let server = Server::new(Arc::new(io));
-/// 	server.start("127.0.0.1:3030", AccessControlAllowOrigin::Null, 1);
+/// 	server.start("127.0.0.1:3030", AccessControlAllowOrigin::Null, 1).unwrap();
 /// }
 /// ```
 pub struct Server {
@@ -130,15 +132,17 @@ impl Server {
 		}
 	}
 
-	pub fn start(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) {
-		hyper::Server::http(addr).unwrap().handle_threads(ServerHandler::new(self.jsonrpc_handler.clone(), cors_domain), threads).unwrap();
+	pub fn start(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) -> ServerResult {
+		try!(hyper::Server::http(addr))
+      .handle_threads(ServerHandler::new(self.jsonrpc_handler.clone(), cors_domain), threads)
 	}
 
-	pub fn start_async(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) {
+	pub fn start_async(&self, addr: &str, cors_domain: AccessControlAllowOrigin, threads: usize) -> thread::JoinHandle<ServerResult> {
 		let address = addr.to_owned();
 		let handler = self.jsonrpc_handler.clone();
 		thread::Builder::new().name("jsonrpc_http".to_string()).spawn(move || {
-			hyper::Server::http(address.as_ref() as &str).unwrap().handle_threads(ServerHandler::new(handler, cors_domain), threads).unwrap();
-		}).unwrap();
+			try!(hyper::Server::http(address.as_ref() as &str))
+        .handle_threads(ServerHandler::new(handler, cors_domain), threads)
+		}).expect("RPC thread spawned")
 	}
 }


### PR DESCRIPTION
1. Exposing `ServerHandler` allows you to configure custom http server and mount rpc with some prefix.
2. Exposing errors allows you to display more friendly messages.