### PR TITLE
Newline after output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ description = "Rust http server using JSONRPC 2.0."
 homepage = "https://github.com/debris/jsonrpc-http-server"
 license = "MIT"
 name = "jsonrpc-http-server"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 keywords = ["jsonrpc", "json-rpc", "json", "rpc", "server"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ impl hyper::server::Handler<HttpStream> for ServerHandler {
     fn on_response_writable(&mut self, encoder: &mut Encoder<HttpStream>) -> Next {
 		if let Some(ref response) = self.response {
 			encoder.write(response.as_bytes()).unwrap();
+      encoder.write(b"\n").unwrap();
 		}
 		Next::end()
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl ServerHandler {
 }
 
 impl hyper::server::Handler<HttpStream> for ServerHandler {
-    fn on_request(&mut self, request: Request) -> Next {
+	fn on_request(&mut self, request: Request) -> Next {
 		match *request.method() {
 			Method::Options => {
 				self.response = Some(String::new());
@@ -107,8 +107,8 @@ impl hyper::server::Handler<HttpStream> for ServerHandler {
 		}
 	}
 
-    /// This event occurs each time the `Request` is ready to be read from.
-    fn on_request_readable(&mut self, decoder: &mut Decoder<HttpStream>) -> Next {
+	/// This event occurs each time the `Request` is ready to be read from.
+	fn on_request_readable(&mut self, decoder: &mut Decoder<HttpStream>) -> Next {
 		match decoder.read_to_string(&mut self.request) {
 			Ok(0) => {
 				self.response = self.jsonrpc_handler.handle_request(&self.request);
@@ -127,8 +127,8 @@ impl hyper::server::Handler<HttpStream> for ServerHandler {
 		}
 	}
 
-    /// This event occurs after the first time this handled signals `Next::write()`.
-    fn on_response(&mut self, response: &mut Response) -> Next {
+		/// This event occurs after the first time this handled signals `Next::write()`.
+	fn on_response(&mut self, response: &mut Response) -> Next {
 		*response.headers_mut() = self.response_headers();
 		if self.response.is_none() {
 			response.set_status(hyper::status::StatusCode::MethodNotAllowed);
@@ -136,11 +136,11 @@ impl hyper::server::Handler<HttpStream> for ServerHandler {
 		Next::write()
 	}
 
-    /// This event occurs each time the `Response` is ready to be written to.
-    fn on_response_writable(&mut self, encoder: &mut Encoder<HttpStream>) -> Next {
+		/// This event occurs each time the `Response` is ready to be written to.
+		fn on_response_writable(&mut self, encoder: &mut Encoder<HttpStream>) -> Next {
 		if let Some(ref response) = self.response {
 			encoder.write(response.as_bytes()).unwrap();
-      encoder.write(b"\n").unwrap();
+			encoder.write(b"\n").unwrap();
 		}
 		Next::end()
 	}


### PR DESCRIPTION
Currently output in console looks akward
```bash
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_coinbase","params":[],"id":64}' http://localhost:8545
{"jsonrpc":"2.0","result":"0x0037a6b811ffeb6e072da21179d11b1406371c63","id":64}Air:release me$
```
